### PR TITLE
Update build.gradle

### DIFF
--- a/gintonic/build.gradle
+++ b/gintonic/build.gradle
@@ -42,7 +42,7 @@ android.libraryVariants.all { variant ->
                          "-aspectpath", javaCompile.classpath.asPath,
                          "-d", javaCompile.destinationDir.toString(),
                          "-classpath", javaCompile.classpath.asPath,
-                         "-bootclasspath", plugin.project.android.bootClasspath.join(
+                         "-bootclasspath", android.bootClasspath.join(
                 File.pathSeparator)]
 
         MessageHandler handler = new MessageHandler(true);


### PR DESCRIPTION
最新的gradle build tool 2.3.0和gradle 3.3之后，gintonic的build.gradle会报错
Error:(45, 1) Execution failed for task ':gintonic:compileReleaseJavaWithJavac'.
> No such property: project for class: com.android.build.gradle.LibraryPlugin
解决方法是
"-bootclasspath", plugin.project.android.bootClasspath.join(File.pathSeparator)
修改为
"-bootclasspath", android.bootClasspath.join(File.pathSeparator)